### PR TITLE
Security: Fix network exposure and add secret redaction

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -62,7 +62,7 @@ services:
     restart: always
     depends_on: *langfuse-depends-on
     ports:
-      - 3150:3000
+      - 127.0.0.1:3150:3000
     environment:
       <<: *langfuse-worker-env
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
@@ -106,7 +106,7 @@ services:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
     ports:
-      - 9190:9000
+      - 127.0.0.1:9190:9000
       - 127.0.0.1:9191:9001
     volumes:
       - langfuse_minio_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     restart: always
     depends_on: *langfuse-depends-on
     ports:
-      - 3050:3000
+      - 127.0.0.1:3050:3000
     environment:
       <<: *langfuse-worker-env
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
@@ -95,7 +95,7 @@ services:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
     ports:
-      - 9090:9000
+      - 127.0.0.1:9090:9000
       - 127.0.0.1:9091:9001
     volumes:
       - langfuse_minio_data:/data

--- a/scripts/install-hook.sh
+++ b/scripts/install-hook.sh
@@ -19,10 +19,19 @@ if [ ! -f .env ]; then
     exit 1
 fi
 
-# Source .env to get credentials
-set -a
-source .env
-set +a
+# Extract credentials from .env (safer than source - avoids code injection)
+get_env_value() {
+    grep "^$1=" .env 2>/dev/null | cut -d= -f2- | head -1
+}
+
+LANGFUSE_INIT_PROJECT_PUBLIC_KEY=$(get_env_value "LANGFUSE_INIT_PROJECT_PUBLIC_KEY")
+LANGFUSE_INIT_PROJECT_SECRET_KEY=$(get_env_value "LANGFUSE_INIT_PROJECT_SECRET_KEY")
+
+if [ -z "$LANGFUSE_INIT_PROJECT_PUBLIC_KEY" ] || [ -z "$LANGFUSE_INIT_PROJECT_SECRET_KEY" ]; then
+    echo -e "${RED}Error: Could not read API keys from .env${NC}"
+    echo "Ensure LANGFUSE_INIT_PROJECT_PUBLIC_KEY and LANGFUSE_INIT_PROJECT_SECRET_KEY are set"
+    exit 1
+fi
 
 # Find Python 3.11+
 PYTHON=""


### PR DESCRIPTION
## Summary

This PR addresses security vulnerabilities identified during a security audit:

### 🔴 Critical: Network Exposure (Fixed)
- **langfuse-web** was bound to `0.0.0.0:3050` - accessible from any network
- **minio S3 API** was bound to `0.0.0.0:9090` - accessible from any network

**Impact:** Anyone on the same WiFi/LAN could access your Langfuse dashboard and all captured Claude Code conversations, including code, prompts, and potentially secrets.

**Fix:** Both services now bind to `127.0.0.1` (localhost only).

### 🟡 Medium: Shell Injection in install-hook.sh (Fixed)
- Script used `source .env` which would execute any shell code in the .env file
- Now uses safe `grep`-based extraction

### 🟢 New: Automatic Secret Redaction
Before sending traces to Langfuse, the hook now automatically redacts:
- OpenAI/Anthropic API keys (`sk-...`)
- Langfuse keys (`sk-lf-...`)  
- Bearer tokens
- Passwords in common formats
- Generic API keys

This is enabled by default. Disable with `CC_LANGFUSE_REDACT=false` if needed.

### 🟢 New: Log Rotation
- Hook log rotates at 10MB, keeps 3 backups
- Prevents unbounded disk usage

## Test Plan
- [x] Unit tests pass
- [x] Docker Compose files validate
- [x] Sanitization patterns verified manually
- [x] All services still bind correctly

## Files Changed
- `docker-compose.yml` - Localhost binding for langfuse-web, minio
- `docker-compose.test.yml` - Same fixes for test config
- `hooks/langfuse_hook.py` - Secret redaction + log rotation
- `scripts/install-hook.sh` - Safe .env parsing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)