### PR TITLE
feat: add OTEL_LOG_TOOL_DETAILS and sync hook with production

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -17,12 +17,20 @@ from pathlib import Path
 from typing import Any
 import socket
 
+# Prevent local directories named "langfuse" (e.g., Docker Compose project dirs)
+# from shadowing the real langfuse SDK via namespace package resolution.
+# Remove CWD and '' from sys.path temporarily during import.
+_original_path = sys.path[:]
+sys.path = [p for p in sys.path if p not in ("", ".") and Path(p).resolve() != Path.cwd().resolve()]
+
 # Check if Langfuse is available
 try:
     from langfuse import Langfuse
 except ImportError:
     print("Error: langfuse package not installed. Run: pip install langfuse", file=sys.stderr)
     sys.exit(0)
+finally:
+    sys.path = _original_path
 
 # Configuration
 LOG_FILE = Path.home() / ".claude" / "state" / "langfuse_hook.log"
@@ -30,6 +38,7 @@ STATE_FILE = Path.home() / ".claude" / "state" / "langfuse_state.json"
 QUEUE_FILE = Path.home() / ".claude" / "state" / "pending_traces.jsonl"
 DEBUG = os.environ.get("CC_LANGFUSE_DEBUG", "").lower() == "true"
 HEALTH_CHECK_TIMEOUT = 2  # seconds
+PERMISSION_EVENTS_FILE = Path.home() / ".claude" / "logs" / "permission-events.jsonl"
 
 
 def log(level: str, message: str) -> None:
@@ -456,6 +465,23 @@ def queue_turns_from_messages(
     return turns
 
 
+def get_permission_flags(session_id: str) -> list[dict]:
+    """Read flagged permission events for the current session."""
+    if not PERMISSION_EVENTS_FILE.exists():
+        return []
+    events = []
+    try:
+        for line in PERMISSION_EVENTS_FILE.read_text().strip().split("\n"):
+            if not line:
+                continue
+            event = json.loads(line)
+            if event.get("session_id") == session_id:
+                events.append(event)
+    except (json.JSONDecodeError, OSError):
+        pass
+    return events
+
+
 def create_trace(
     langfuse: Langfuse,
     session_id: str,
@@ -557,6 +583,22 @@ def create_trace(
             ) as tool_span:
                 tool_span.update(output=tool_call["output"])
             debug(f"Created span for tool: {tool_call['name']}")
+
+        # Add permission governance data
+        perm_events = get_permission_flags(session_id)
+        if perm_events:
+            tags.append("has-permission-flags")
+            langfuse.update_current_trace(tags=tags)
+            flag_summary = {}
+            for evt in perm_events:
+                for flag in evt.get("flags", []):
+                    flag_summary[flag] = flag_summary.get(flag, 0) + 1
+            with langfuse.start_as_current_span(
+                name="Permission Events",
+                input={"flagged_event_count": len(perm_events), "flag_summary": flag_summary},
+                metadata={"source": "claude-governance"},
+            ) as perm_span:
+                perm_span.update(output={"events": perm_events})
 
         # Update trace with output
         trace_span.update(output={"role": "assistant", "content": final_output})

--- a/settings-examples/cloud-settings.json
+++ b/settings-examples/cloud-settings.json
@@ -3,7 +3,8 @@
     "TRACE_TO_LANGFUSE": "true",
     "LANGFUSE_PUBLIC_KEY": "pk-lf-YOUR_PUBLIC_KEY",
     "LANGFUSE_SECRET_KEY": "sk-lf-YOUR_SECRET_KEY",
-    "LANGFUSE_HOST": "https://cloud.langfuse.com"
+    "LANGFUSE_HOST": "https://cloud.langfuse.com",
+    "OTEL_LOG_TOOL_DETAILS": "1"
   },
   "hooks": {
     "Stop": [

--- a/settings-examples/global-settings-uv.json
+++ b/settings-examples/global-settings-uv.json
@@ -3,7 +3,8 @@
     "TRACE_TO_LANGFUSE": "true",
     "LANGFUSE_PUBLIC_KEY": "YOUR_PUBLIC_KEY_HERE",
     "LANGFUSE_SECRET_KEY": "YOUR_SECRET_KEY_HERE",
-    "LANGFUSE_HOST": "https://cloud.langfuse.com"
+    "LANGFUSE_HOST": "https://cloud.langfuse.com",
+    "OTEL_LOG_TOOL_DETAILS": "1"
   },
   "hooks": {
     "Stop": [

--- a/settings-examples/global-settings.json
+++ b/settings-examples/global-settings.json
@@ -3,7 +3,8 @@
     "TRACE_TO_LANGFUSE": "true",
     "LANGFUSE_PUBLIC_KEY": "pk-lf-local-claude-code",
     "LANGFUSE_SECRET_KEY": "YOUR_SECRET_KEY_HERE",
-    "LANGFUSE_HOST": "http://localhost:3050"
+    "LANGFUSE_HOST": "http://localhost:3050",
+    "OTEL_LOG_TOOL_DETAILS": "1"
   },
   "hooks": {
     "Stop": [


### PR DESCRIPTION
## Summary

- Add `OTEL_LOG_TOOL_DETAILS=1` to all 3 settings examples — enables `skill_name` and tool parameter details on telemetry events, needed for skill invocation tracking
- Sync `langfuse_hook.py` with production: sys.path fix (prevents local `langfuse/` dirs from shadowing the SDK) and permission governance tracking (`Permission Events` spans with flag summaries)

## Context

Investigation of skill invocation tracking in Langfuse revealed that without `OTEL_LOG_TOOL_DETAILS=1`, skill names aren't attached to telemetry events. The hook also had production-only improvements not reflected in the template.

Skill cross-turn linkage (zero-duration spans, no parent link between trigger and execution traces) is tracked as future work — it's an upstream Claude Code limitation (anthropics/claude-code#35319).

Fixes #12

## Test plan

- [ ] Verify settings examples parse as valid JSON
- [ ] Run hook against a session with skill invocations and confirm `skill_name` appears in Langfuse traces
- [ ] Verify permission events span appears when `permission-events.jsonl` has entries
- [ ] Test sys.path fix by running hook from a directory containing a `langfuse/` folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)